### PR TITLE
Fix Paladeo for Monday

### DIFF
--- a/restaurants/paladeo
+++ b/restaurants/paladeo
@@ -24,4 +24,4 @@ Friday)
     exit 0
 esac
 
-curl -s "http://www.paladeo.cz/menu" | grep -A10 "<u>$TODAY_CZ" | sed  's/<[^>]*>//g' | sed 's/^\s*//g' | grep -v '^&' | grep -e '^$' -v 
+curl -s "http://www.paladeo.cz/menu" | grep -A10 "[ug]>$TODAY_CZ" | sed  's/<[^>]*>//g' | sed 's/^\s*//g' | grep -v '^&' | grep -e '^$' -v 


### PR DESCRIPTION
The hacker-proof layout of paladeo.cz really makes it hard for parsers
to get a meaningful value from the page.

All weekdays, except Monday, are enclosed in
`<strong><u>DAY_NAME</u></strong>`
For Monday the enclosing tags are switched:
`<u><strong>Monday</strong></u>`

This patch adjusts the regexp so that Monday works as well.
